### PR TITLE
fix: CAS修复时间轮并发问题

### DIFF
--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
@@ -13,8 +13,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
  * @author xuxueli 2019-05-21
@@ -33,7 +33,7 @@ public class JobScheduleHelper {
     private Thread ringThread;
     private volatile boolean scheduleThreadToStop = false;
     private volatile boolean ringThreadToStop = false;
-    private volatile static Map<Integer, List<Integer>> ringData = new ConcurrentHashMap<>();
+    private static final AtomicReferenceArray<List<Integer>> ringData = new AtomicReferenceArray<List<Integer>>(new List[60]);
 
     public void start(){
 
@@ -238,7 +238,7 @@ public class JobScheduleHelper {
                         List<Integer> ringItemData = new ArrayList<>();
                         int nowSecond = Calendar.getInstance().get(Calendar.SECOND);   // 避免处理耗时太长，跨过刻度，向前校验一个刻度；
                         for (int i = 0; i < 2; i++) {
-                            List<Integer> tmpData = ringData.remove( (nowSecond+60-i)%60 );
+                            List<Integer> tmpData = ringData.getAndSet((nowSecond + 60 - i) % 60, null); // CAS读取并置空，put时就获取不到即将被消费的list，避免并发操作同一个list
                             if (tmpData != null) {
                                 ringItemData.addAll(tmpData);
                             }
@@ -285,12 +285,12 @@ public class JobScheduleHelper {
 
     private void pushTimeRing(int ringSecond, int jobId){
         // push async ring
-        List<Integer> ringItemData = ringData.get(ringSecond);
+        List<Integer> ringItemData = ringData.getAndSet(ringSecond, null);
         if (ringItemData == null) {
             ringItemData = new ArrayList<Integer>();
-            ringData.put(ringSecond, ringItemData);
         }
         ringItemData.add(jobId);
+        ringData.set(ringSecond, ringItemData);
 
         logger.debug(">>>>>>>>>>> xxl-job, schedule push time-ring : " + ringSecond + " = " + Arrays.asList(ringItemData) );
     }
@@ -316,13 +316,11 @@ public class JobScheduleHelper {
 
         // if has ring data
         boolean hasRingData = false;
-        if (!ringData.isEmpty()) {
-            for (int second : ringData.keySet()) {
-                List<Integer> tmpData = ringData.get(second);
-                if (tmpData!=null && tmpData.size()>0) {
-                    hasRingData = true;
-                    break;
-                }
+        for (int second = 0; second < 60; second++) {
+            List<Integer> tmpData = ringData.get(second);
+            if (tmpData != null && tmpData.size() > 0) {
+                hasRingData = true;
+                break;
             }
         }
         if (hasRingData) {

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/core/thread/JobScheduleHelper.java
@@ -33,7 +33,7 @@ public class JobScheduleHelper {
     private Thread ringThread;
     private volatile boolean scheduleThreadToStop = false;
     private volatile boolean ringThreadToStop = false;
-    private static final AtomicReferenceArray<List<Integer>> ringData = new AtomicReferenceArray<List<Integer>>(new List[60]);
+    private static final AtomicReferenceArray<List<Integer>> ringData = new AtomicReferenceArray<>(60);
 
     public void start(){
 


### PR DESCRIPTION
Please answer some questions before submitting your issue. Thanks!

### Which version of XXL-JOB do you using?

2.4.1

### Expected behavior

### Actual behavior

### Steps to reproduce the behavior

### 问题说明

时间轮Map由于remove和get没有并发控制，存在并发问题。

现假设线程A往map添加jobId，线程2读取jobId, 为了简便，都假设对同一个ringSecond读取

| pushTimeRing方法操作序列 | remove操作序列  |	
|:-------------------|:-----------:|
| get                |   remove    |
| add                | list.addAll |

此时，假如A获取了list，并且不为null

B进行remove，也获取了不为空的list并且B.read操作先于A.add

| 步骤 | 线程A |     线程B     |     
|:--:|:---:|:-----------:|
| 1  | get |             |      
| 2  |     |   remove    |         
| 3  |     | list.addAll |    
| 4  | add |             |          

那么A.add的jobId将会丢失，因为A往list里add了该id，但map已经没有该list引用了，下次B执行remove时。获取不到该list

在秒级任务超过1w时，就会出现任务丢失现象，概率很低，但并不是没有


### 解决方式
1.尝试使用过线程安全list，并不管用
2.尝试使用过 issue: #2892的方案，无效
上述两方案能降低丢失概率，方案1在2w任务级别出现任务丢失
方案2在4w级别出现任务丢失。但没有解决本质问题：向没有被map引用的list添加了数据

最终方案：使用AtomicReferenceArray类CAS操作，取代Map。

关键代码如下：
```java

private static void pushTimeRing(int ringSecond,int jobId){
        List<Integer> ringItemData
        =ringArr.getAndSet(ringSecond,null); // 这里get的同时将引用置空，避免remove的时候获取到同一个list并发操作
        if(ringItemData==null){
        ringItemData=new ArrayList<>();
        }
        ringItemData.add(job);
        ringArr.set(ringSecond,ringItemData);     // 由于前面已经将该index位置置空，直接赋值即可
        }


        ...省略部分代码

// 消费线程：
        for(int i=0;i< 2;i++){
        List<Integer> tmpData = ringArr.getAndSet((nowSecond+60-i)%60); // CAS读取并置空，这样put时获取不到即将被消费的list，避免并发操作同一个list
        if(tmpData!=null){
        ringItemData.addAll(tmpData);
        }
        }

```

经过测试，并未发现任务丢失，并且效率很高，单秒10w任务下，put总时间为毫秒级


ps: 
1. 测试环境为本地IDE，16G，i7-12700
2. 测试目的为检测任务生产(put)和消费(remove)的并发问题，所以并未执行实际的jobTrigger（可以理解为jobTrigger只打日志)
3. 测试数据量为5000,1w,2w,4w,10w
4. 由于条件2，本地任务put操作效率偏高，并发量大，实际肯定偏低，但不会低很多。这块我后续测试补充下


### Other information
